### PR TITLE
fix #37

### DIFF
--- a/grammars/mcfunction.json
+++ b/grammars/mcfunction.json
@@ -59,7 +59,6 @@
 		{
 			"match": "^#.*",
 			"name": "comment",
-
 			"captures": {
 				"0": {
 					"patterns": [
@@ -82,22 +81,6 @@
 		{
 			"match": "(?<!\\w)(\\d+(?=[bfsdl])[bfsdl]|([~\\-^]*\\d+|[~|^]))(?!\\w)",
 			"name": "number"
-		},
-		{
-			"match": "(?<=scoreboard objectives) (?:add|remove|setdisplay sidebar|modify) ([^\\s]{17,})",
-			"captures": {
-				"1": {
-					"name": "error"
-				}
-			}
-		},
-		{
-			"match": "(?<=scoreboard) (?:players (?:add|remove|set|get|reset) [^\\s]+) ([^\\s]{17,})",
-			"captures": {
-				"1": {
-					"name": "error"
-				}
-			}
 		},
 		{
 			"match": "(?<=team) (?:add|remove|join|empty|list) ([^\\s]{17,})",


### PR DESCRIPTION
Removed error when scoreboard name is longer than 16 characters. This limit dowsn't exists in the newest verion and also caused the error in #37